### PR TITLE
fix: ECR immutable tag 충돌 시 build+push 스킵 처리

### DIFF
--- a/.github/workflows/AI-CICD.yml
+++ b/.github/workflows/AI-CICD.yml
@@ -146,9 +146,19 @@ jobs:
           echo "short_sha=${SHORT_SHA}" >> "$GITHUB_OUTPUT"
           echo "image=${{ steps.ecr-login.outputs.registry }}/${{ env.ECR_REPOSITORY }}:${SHORT_SHA}" >> "$GITHUB_OUTPUT"
 
+      - name: Check if image exists
+        id: check
+        run: |
+          aws ecr describe-images \
+            --repository-name ${{ env.ECR_REPOSITORY }} \
+            --image-ids imageTag=${{ steps.meta.outputs.short_sha }} \
+            > /dev/null 2>&1 && echo "exists=true" >> "$GITHUB_OUTPUT" || echo "exists=false" >> "$GITHUB_OUTPUT"
+
       - uses: docker/setup-buildx-action@v3
+        if: steps.check.outputs.exists == 'false'
 
       - name: Build and push
+        if: steps.check.outputs.exists == 'false'
         uses: docker/build-push-action@v6
         with:
           context: .


### PR DESCRIPTION
## Summary
- 워크플로우 재실행 시 동일 커밋 SHA 태그가 이미 ECR에 존재하면 `ImageTagAlreadyExistsException` 발생
- `aws ecr describe-images`로 태그 존재 여부를 먼저 확인하고, 이미 있으면 build/push 단계를 건너뛰도록 수정

## 배경
- ECR 레포지토리에 `IMMUTABLE` 태그 정책이 적용되어 있어 같은 태그로 재push 불가
- 배포 실패 후 워크플로우를 다시 실행하면 이미지 빌드는 성공하지만 push에서 실패
- 이미지가 이미 존재하면 빌드 자체를 스킵하여 불필요한 시간 소모도 방지

## 변경 내용
- `deploy-dev` job에 "Check if image exists" step 추가
- `docker/setup-buildx-action`, `docker/build-push-action`에 `if: steps.check.outputs.exists == 'false'` 조건 추가

## Test plan
- [x] 새 커밋 push → 정상 빌드+push 확인
- [x] 같은 커밋으로 워크플로우 재실행 → build/push 스킵, 배포만 실행 확인