### PR TITLE
add fallback providers for LLM and STT with TTL-based retry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ jupyter/
 
 # OS
 .DS_Store
+
+# 문서 팡리
+docs/

--- a/core/config.py
+++ b/core/config.py
@@ -35,7 +35,7 @@ class Settings(BaseSettings):
 
     # gemini
     GEMINI_API_KEY: str
-    GEMINI_MODEL_ID: str = "gemini-2.5-pro"
+    GEMINI_MODEL_ID: str = "gemini-2.5-flash"
 
     # Callback 설정 (V2)
     feedback_callback_url: str = "http://backend-server/ai/interview/feedback/callback"

--- a/core/dependencies.py
+++ b/core/dependencies.py
@@ -3,28 +3,44 @@ from core.config import get_settings
 from providers.llm.base import LLMProvider
 from providers.llm.vllm import VLLMProvider
 from providers.llm.gemini import GeminiProvider
+from providers.llm.fallback import FallbackLLMProvider
+from providers.stt.huggingface import transcribe as hf_transcribe
+from providers.stt.gpu_stt import transcribe as gpu_transcribe
+from providers.stt.base import STTProvider, SimpleSTTProvider
+from providers.stt.fallback import FallbackSTTProvider
 
-
-# from providers.stt.base import STTProvider
-# from providers.stt.huggingface import HuggingFaceSTTProvider
 settings = get_settings()
 
-_provider_cache: dict[str, LLMProvider] = {}
+_llm_cache: dict[str, LLMProvider] = {}
+_stt_cache: dict[str, STTProvider] = {}
+
 
 def get_llm_provider(provider: str | None = None) -> LLMProvider:
     provider_name = provider or settings.LLM_PROVIDER
-    if provider_name not in _provider_cache:
+    if provider_name not in _llm_cache:
         if provider_name == "vllm":
-            _provider_cache[provider_name] = VLLMProvider()
+            _llm_cache[provider_name] = FallbackLLMProvider(
+                primary=VLLMProvider(),
+                fallback=GeminiProvider(thinking_budget=0),
+            )
         else:
-            _provider_cache[provider_name] = GeminiProvider()
-    return _provider_cache[provider_name]
+            _llm_cache[provider_name] = GeminiProvider(thinking_budget=1024)
+    return _llm_cache[provider_name]
 
 
-# @lru_cache  
-# def get_stt_provider() -> STTProvider:
-#     if settings.STT_PROVIDER == "huggingface":
-
-#         return HuggingFaceSTTProvider()
-
-#     return RunpodSTTProvider()
+def get_stt_provider(provider: str | None = None) -> STTProvider:
+    provider_name = provider or settings.STT_PROVIDER
+    if provider_name not in _stt_cache:
+        if provider_name == "gpu_stt":
+            _stt_cache[provider_name] = FallbackSTTProvider(
+                primary_fn=gpu_transcribe,
+                primary_name="gpu_stt",
+                fallback_fn=hf_transcribe,
+                fallback_name="huggingface",
+            )
+        else:
+            _stt_cache[provider_name] = SimpleSTTProvider(
+                transcribe_fn=hf_transcribe,
+                name="huggingface",
+            )
+    return _stt_cache[provider_name]

--- a/providers/llm/fallback.py
+++ b/providers/llm/fallback.py
@@ -1,0 +1,137 @@
+# providers/llm/fallback.py
+
+import time
+from typing import Type, TypeVar
+
+from pydantic import BaseModel
+
+from providers.llm.vllm import VLLMProvider
+from providers.llm.gemini import GeminiProvider
+from core.logging import get_logger
+from exceptions.exceptions import AppException
+from exceptions.error_messages import ErrorMessage
+
+T = TypeVar("T", bound=BaseModel)
+logger = get_logger(__name__)
+
+_FALLBACK_ERRORS = {
+    ErrorMessage.LLM_SERVICE_UNAVAILABLE,
+    ErrorMessage.LLM_TIMEOUT,
+}
+
+
+class FallbackLLMProvider:
+    """vLLM primary → Gemini fallback Provider (TTL 기반 Lazy 재시도)
+
+    - vLLM 호출 실패(연결 불가/타임아웃) 시 Gemini로 자동 전환
+    - TTL(RETRY_INTERVAL) 경과 후 다음 요청에서 vLLM 재시도
+    - 재시도 성공 시 vLLM 복귀, 실패 시 TTL 갱신 후 Gemini 유지
+
+    NOTE: TTL 만료 직후 vLLM 재시도-실패 시, 해당 1회 요청은
+    vLLM용 system_prompt로 Gemini가 호출될 수 있음 (provider_name 참조 시점 차이).
+    다음 요청부터는 provider_name이 "gemini"를 반환하므로 정상 동작.
+    """
+
+    DEFAULT_RETRY_INTERVAL = 300  # 5분
+
+    def __init__(
+        self,
+        primary: VLLMProvider,
+        fallback: GeminiProvider,
+        retry_interval: int = DEFAULT_RETRY_INTERVAL,
+    ):
+        self._primary = primary
+        self._fallback = fallback
+        self._retry_interval = retry_interval
+        self._fallback_since: float | None = None
+
+    @property
+    def _using_fallback(self) -> bool:
+        if self._fallback_since is None:
+            return False
+        if time.time() - self._fallback_since > self._retry_interval: # TTL 만료 시 vLLM 재시도 허용
+            logger.info("TTL 만료 → vLLM 재시도 허용")
+            self._fallback_since = None
+            return False
+        return True
+
+    def _mark_fallback(self) -> None:
+        self._fallback_since = time.time()
+        logger.warning(
+            f"vLLM → Gemini fallback 전환 | "
+            f"retry_after={self._retry_interval}s"
+        )
+
+    @property
+    def provider_name(self) -> str:
+        if self._using_fallback:
+            return self._fallback.provider_name
+        return self._primary.provider_name
+
+    def _is_fallback_error(self, exc: AppException) -> bool:
+        try:
+            return ErrorMessage(exc.message) in _FALLBACK_ERRORS
+        except ValueError:
+            return False
+
+    async def generate(
+        self,
+        prompt: str,
+        response_model: Type[T],
+        *,
+        system_prompt: str | None = None,
+        temperature: float = 0.7,
+        max_tokens: int = 2000,
+    ) -> str:
+        if not self._using_fallback:
+            try:
+                return await self._primary.generate(
+                    prompt=prompt,
+                    response_model=response_model,
+                    system_prompt=system_prompt,
+                    temperature=temperature,
+                    max_tokens=max_tokens,
+                )
+            except AppException as e:
+                if not self._is_fallback_error(e):
+                    raise
+                self._mark_fallback()
+
+        return await self._fallback.generate(
+            prompt=prompt,
+            response_model=response_model,
+            system_prompt=system_prompt,
+            temperature=temperature,
+            max_tokens=max_tokens,
+        )
+
+    async def generate_structured(
+        self,
+        prompt: str,
+        response_model: Type[T],
+        *,
+        system_prompt: str | None = None,
+        temperature: float = 0.3,
+        max_tokens: int = 4000,
+    ) -> T:
+        if not self._using_fallback:
+            try:
+                return await self._primary.generate_structured(
+                    prompt=prompt,
+                    response_model=response_model,
+                    system_prompt=system_prompt,
+                    temperature=temperature,
+                    max_tokens=max_tokens,
+                )
+            except AppException as e:
+                if not self._is_fallback_error(e):
+                    raise
+                self._mark_fallback()
+
+        return await self._fallback.generate_structured(
+            prompt=prompt,
+            response_model=response_model,
+            system_prompt=system_prompt,
+            temperature=temperature,
+            max_tokens=max_tokens,
+        )

--- a/providers/llm/gemini.py
+++ b/providers/llm/gemini.py
@@ -28,7 +28,7 @@ class GeminiProvider:
         self,
         api_key: str | None = None,
         model: str | None = None,
-        thinking_budget: int = 1024
+        thinking_budget: int = 0
     ):
         self.client = genai.Client(api_key=api_key or settings.GEMINI_API_KEY)
         self.model = model or settings.GEMINI_MODEL_ID
@@ -85,27 +85,15 @@ class GeminiProvider:
         schema = response_model.model_json_schema()
         task_name = response_model.__name__
 
-        # thinking 모델 사용 시
         config = types.GenerateContentConfig(
             temperature=temperature,
-            max_output_tokens=max_tokens,
+            max_output_tokens=max_tokens + self.thinking_budget,
             response_mime_type="application/json",
             response_schema=schema,
             thinking_config=types.ThinkingConfig(
-                thinking_budget=self.thinking_budget  # 0이면 thinking 비활성화
+                thinking_budget=self.thinking_budget
             ),
         )
-
-        # 일반 flash 모델 사용 시
-        # config = types.GenerateContentConfig(
-        #     temperature=temperature,
-        #     max_output_tokens=max_tokens,
-        #     response_mime_type="application/json",
-        #     response_schema=schema,
-        #     thinking_config=types.ThinkingConfig(
-        #         thinking_budget=self.thinking_budget  # 0이면 thinking 비활성화
-        #     ),
-        # )
 
         response = await self._call_api(full_prompt, task_name, config)
 

--- a/providers/stt/base.py
+++ b/providers/stt/base.py
@@ -1,6 +1,22 @@
-from typing import Protocol
+from typing import Protocol, Callable, Awaitable
+
 
 class STTProvider(Protocol):
+    @property
+    def provider_name(self) -> str: ...
+    async def transcribe(self, audio_url: str) -> str: ...
+
+
+class SimpleSTTProvider:
+    """단일 STT 함수를 STTProvider 인터페이스로 감싸는 래퍼"""
+
+    def __init__(self, transcribe_fn: Callable[[str], Awaitable[str]], name: str):
+        self._fn = transcribe_fn
+        self._name = name
+
+    @property
+    def provider_name(self) -> str:
+        return self._name
+
     async def transcribe(self, audio_url: str) -> str:
-        """ 음성 파일을 텍스트로 변환"""
-        ...
+        return await self._fn(audio_url)

--- a/providers/stt/fallback.py
+++ b/providers/stt/fallback.py
@@ -1,0 +1,85 @@
+# providers/stt/fallback.py
+
+import time
+from typing import Callable, Awaitable
+
+from core.logging import get_logger
+from exceptions.exceptions import AppException
+from exceptions.error_messages import ErrorMessage
+
+logger = get_logger(__name__)
+
+TranscribeFunc = Callable[[str], Awaitable[str]]
+
+_FALLBACK_ERRORS = {
+    ErrorMessage.STT_SERVICE_UNAVAILABLE,
+    ErrorMessage.STT_TIMEOUT,
+    ErrorMessage.SERVER_CONNECTION_FAILED,
+}
+
+
+class FallbackSTTProvider:
+    """GPU STT primary → HuggingFace fallback Provider (TTL 기반 Lazy 재시도)
+
+    - GPU STT 호출 실패(연결 불가/타임아웃/503) 시 HuggingFace로 자동 전환
+    - TTL(retry_interval) 경과 후 다음 요청에서 GPU STT 재시도
+    - 재시도 성공 시 GPU STT 복귀, 실패 시 TTL 갱신 후 HuggingFace 유지
+    """
+
+    DEFAULT_RETRY_INTERVAL = 300  # 5분
+
+    def __init__(
+        self,
+        primary_fn: TranscribeFunc,
+        primary_name: str,
+        fallback_fn: TranscribeFunc,
+        fallback_name: str,
+        retry_interval: int = DEFAULT_RETRY_INTERVAL,
+    ):
+        self._primary_fn = primary_fn
+        self._primary_name = primary_name
+        self._fallback_fn = fallback_fn
+        self._fallback_name = fallback_name
+        self._retry_interval = retry_interval
+        self._fallback_since: float | None = None
+
+    @property
+    def _using_fallback(self) -> bool:
+        if self._fallback_since is None:
+            return False
+        if time.time() - self._fallback_since > self._retry_interval:
+            logger.info("TTL 만료 → GPU STT 재시도 허용")
+            self._fallback_since = None
+            return False
+        return True
+
+    def _mark_fallback(self) -> None:
+        self._fallback_since = time.time()
+        logger.warning(
+            f"GPU STT → HuggingFace fallback 전환 | "
+            f"retry_after={self._retry_interval}s"
+        )
+
+    @property
+    def provider_name(self) -> str:
+        if self._using_fallback:
+            return self._fallback_name
+        return self._primary_name
+
+    @staticmethod
+    def _is_fallback_error(exc: AppException) -> bool:
+        try:
+            return ErrorMessage(exc.message) in _FALLBACK_ERRORS
+        except ValueError:
+            return False
+
+    async def transcribe(self, audio_url: str) -> str:
+        if not self._using_fallback:
+            try:
+                return await self._primary_fn(audio_url)
+            except AppException as e:
+                if not self._is_fallback_error(e):
+                    raise
+                self._mark_fallback()
+
+        return await self._fallback_fn(audio_url)

--- a/services/stt_service.py
+++ b/services/stt_service.py
@@ -1,26 +1,12 @@
-from typing import Callable, Awaitable
-
 from langfuse import observe
 
-from core.config import get_settings
 from core.logging import get_logger
 from core.tracing import update_span
+from core.dependencies import get_stt_provider
 from exceptions.exceptions import AppException
 from exceptions.error_messages import ErrorMessage
-from providers.stt.huggingface import transcribe
-from providers.stt.gpu_stt import transcribe as runpod_transcribe   
 
 logger = get_logger(__name__)
-
-# Provider 함수 타입
-TranscribeFunc = Callable[[str], Awaitable[str]]
-settings = get_settings()
-
-def get_stt_provider() -> tuple[TranscribeFunc, str]:
-    """설정에 따라 STT provider와 이름 반환"""
-    if settings.STT_PROVIDER == "gpu_stt":
-        return runpod_transcribe, "gpu_stt"
-    return transcribe, "huggingface"
 
 
 @observe(name="stt_service")
@@ -30,12 +16,11 @@ async def process_transcribe(audio_url: str) -> str:
     file_name = audio_url.split('?')[0].split('/')[-1] if audio_url else "unknown"
     logger.debug(f"STT transcribe start | file={file_name}")
 
-    # 2. STT 변환 처리
-    provider, provider_name = get_stt_provider()
-    update_span(metadata={"provider": provider_name, "file_name": file_name})
+    provider = get_stt_provider()
+    update_span(metadata={"provider": provider.provider_name, "file_name": file_name})
 
     try:
-        text = await provider(audio_url)
+        text = await provider.transcribe(audio_url)
 
         if not text or not text.strip():
             logger.warning(f"STT result is empty | file={file_name}")   


### PR DESCRIPTION
## Issue
- #131 

## 📋 Summary
- GPU 인스턴스(Runpod) 비가용 시 자동으로 Gemini/HuggingFace로 전환되는 Fallback Provider 도입
- TTL 기반 Lazy 재시도 방식으로, fallback 전환 후 5분 경과 시 GPU 복귀를 자동 시도
- LLM(vLLM → Gemini)과 STT(GPU STT → HuggingFace) 모두 적용

## 🔧 Changes

### New Files
- `providers/llm/fallback.py` — FallbackLLMProvider (vLLM primary → Gemini fallback)
- `providers/stt/fallback.py` — FallbackSTTProvider (GPU STT primary → HuggingFace fallback)

### Modified Files
- `core/dependencies.py` — provider 생성 로직 중앙화, FallbackProvider 적용
- `providers/stt/base.py` — STTProvider Protocol에 provider_name 추가, SimpleSTTProvider 래퍼
- `providers/llm/gemini.py` — max_output_tokens에 thinking_budget 자동 가산
- `services/stt_service.py` — get_stt_provider를 dependencies로 이동
- `graphs/nodes/feedback_generator.py` — get_llm_provider("vllm") 하드코딩 제거

## 🤔 Design Decisions
- **왜 FallbackProvider 래퍼?** — 노드 코드 변경 없이 dependencies.py 한 곳에서 적용 가능
- **왜 TTL 기반 Lazy 재시도?** — 백그라운드 health check 대비 구현 단순, asyncio Task 관리 불필요
- **왜 health check 없이 바로 재시도?** — ConnectError 1~3초면 health check(5초)보다 빠름
- **Fallback 대상 에러** — 인프라 장애(SERVICE_UNAVAILABLE, TIMEOUT, CONNECTION_FAILED)만 fallback. 응답 파싱 실패/입력 오류는 fallback하지 않음
- **Gemini thinking 비활성** — fallback용 Gemini는 thinking_budget=0 (vLLM과 동작 일관성 + 토큰 절약)

## 🔀 Fallback Flow
요청 → vLLM 시도 → 성공 → 응답
→ 실패 → Gemini 전환 (TTL 5분 시작)
→ TTL 내 요청 → Gemini 직행
→ TTL 만료 → vLLM 재시도
→ 성공 → vLLM 복귀
→ 실패 → TTL 갱신 → Gemini 유지