### PR TITLE
feat: CI/CD에 Alloy 사이드카 배포 파일 다운로드 추가

### DIFF
--- a/.github/workflows/AI-CICD.yml
+++ b/.github/workflows/AI-CICD.yml
@@ -14,11 +14,13 @@ permissions:
 env:
   AWS_REGION: ap-northeast-2
   ECR_REPOSITORY: qfeed-ecr-ai
+  DEPLOY_RAW_BASE_DEV: https://raw.githubusercontent.com/100-hours-a-week/17-JinyUs-Q-Feed-Cloud/main/deploy/dev/ai
+  DEPLOY_RAW_BASE_PROD: https://raw.githubusercontent.com/100-hours-a-week/17-JinyUs-Q-Feed-Cloud/main/deploy/prod/ai
 
 jobs:
   ci:
     name: CI - Lint and Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
 
     steps:
       - uses: actions/checkout@v4
@@ -123,7 +125,7 @@ jobs:
   deploy-dev:
     name: Deploy to Dev
     needs: ci
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     if: github.ref == 'refs/heads/dev' && github.event_name == 'push'
 
     steps:
@@ -173,7 +175,17 @@ jobs:
           COMMAND_ID=$(aws ssm send-command \
             --document-name "AWS-RunShellScript" \
             --targets '[{"Key":"tag:Name","Values":["qfeed-dev-ec2-ai"]}]' \
-            --parameters '{"commands":["mkdir -p /srv/qfeed && curl -sfL https://raw.githubusercontent.com/100-hours-a-week/17-JinyUs-Q-Feed-Cloud/main/deploy/dev/ai/deploy.sh -o /srv/qfeed/deploy.sh && cd /srv/qfeed && bash deploy.sh ${{ steps.meta.outputs.short_sha }}"],"executionTimeout":["600"]}' \
+            --parameters '{
+              "commands":[
+                "set -e",
+                "mkdir -p /srv/qfeed/alloy",
+                "curl -sfL ${{ env.DEPLOY_RAW_BASE_DEV }}/deploy.sh          -o /srv/qfeed/deploy.sh",
+                "curl -sfL ${{ env.DEPLOY_RAW_BASE_DEV }}/docker-compose.yml -o /srv/qfeed/docker-compose.yml",
+                "curl -sfL ${{ env.DEPLOY_RAW_BASE_DEV }}/alloy/config.alloy -o /srv/qfeed/alloy/config.alloy",
+                "cd /srv/qfeed && bash deploy.sh ${{ steps.meta.outputs.short_sha }}"
+              ],
+              "executionTimeout":["600"]
+            }' \
             --timeout-seconds 600 \
             --comment "Deploy AI ${{ steps.meta.outputs.short_sha }}" \
             --output text --query "Command.CommandId")
@@ -210,10 +222,9 @@ jobs:
             -H "Content-Type: application/json" \
             -d "{\"embeds\":[{\"title\":\"✅ AI Dev 배포 완료\",\"description\":\"이미지 \`${{ steps.meta.outputs.short_sha }}\` 배포 성공\",\"color\":3066993}]}"
 
-  # NOTE: prod 인프라 전환 완료 후 deploy-dev와 동일한 방식(OIDC+SSM)으로 교체 예정
   deploy-prod:
     name: Deploy to EC2 (Prod)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     needs: ci
 
     # main 브랜치로 push된 경우에만 배포 실행 (PR에서는 실행하지 않음)
@@ -267,7 +278,17 @@ jobs:
           COMMAND_ID=$(aws ssm send-command \
             --document-name "AWS-RunShellScript" \
             --targets '[{"Key":"tag:Name","Values":["qfeed-prod-ec2-ai"]}]' \
-            --parameters '{"commands":["mkdir -p /srv/qfeed && curl -sfL https://raw.githubusercontent.com/100-hours-a-week/17-JinyUs-Q-Feed-Cloud/main/deploy/prod/ai/deploy.sh -o /srv/qfeed/deploy.sh && cd /srv/qfeed && bash deploy.sh ${{ steps.meta.outputs.short_sha }}"],"executionTimeout":["600"]}' \
+            --parameters '{
+              "commands":[
+                "set -e",
+                "mkdir -p /srv/qfeed/alloy",
+                "curl -sfL ${{ env.DEPLOY_RAW_BASE_PROD }}/deploy.sh          -o /srv/qfeed/deploy.sh",
+                "curl -sfL ${{ env.DEPLOY_RAW_BASE_PROD }}/docker-compose.yml -o /srv/qfeed/docker-compose.yml",
+                "curl -sfL ${{ env.DEPLOY_RAW_BASE_PROD }}/alloy/config.alloy -o /srv/qfeed/alloy/config.alloy",
+                "cd /srv/qfeed && bash deploy.sh ${{ steps.meta.outputs.short_sha }}"
+              ],
+              "executionTimeout":["600"]
+            }' \
             --timeout-seconds 600 \
             --comment "Deploy AI ${{ steps.meta.outputs.short_sha }}" \
             --output text --query "Command.CommandId")
@@ -306,7 +327,7 @@ jobs:
 
   discord-ci-failure:
     name: Discord 알림 (CI 실패)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     needs: ci
     if: always() && needs.ci.result == 'failure'
     steps:
@@ -354,7 +375,7 @@ jobs:
 
   discord-deploy-dev-failure:
     name: Discord 알림 (Dev 배포 실패)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     needs: deploy-dev
     if: always() && needs.deploy-dev.result == 'failure'
     steps:
@@ -367,7 +388,7 @@ jobs:
 
   discord-deploy-prod-failure:
     name: Discord 알림 (Prod 배포 실패)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     needs: deploy-prod
     if: always() && needs.deploy-prod.result == 'failure'
     steps:


### PR DESCRIPTION
## Summary

- 배포 시 EC2에 `docker-compose.yml`과 `alloy/config.alloy`를 추가로 다운로드하도록 SSM command 수정
- AI 컨테이너와 함께 Alloy 사이드카가 기동되어 호스트 메트릭(Prometheus push) + 컨테이너 로그(Loki push) 수집
- CI/CD runner를 `ubuntu-24.04-arm`으로 변경 (EC2 ARM 아키텍처 일치)

## Changes

### 환경변수 추가
- `DEPLOY_RAW_BASE_DEV` / `DEPLOY_RAW_BASE_PROD`: Cloud 레포 raw URL base path

### SSM Deploy Command 변경 (Dev/Prod 동일)
```
Before: deploy.sh만 다운로드
After:  deploy.sh + docker-compose.yml + alloy/config.alloy 다운로드
```

### Runner 변경
- `ubuntu-latest` → `ubuntu-24.04-arm` (전체 job)

## Test plan

- [x] Dev 브랜치 push 시 CI/CD 정상 실행
- [x] EC2에 docker-compose.yml, alloy/config.alloy 다운로드 확인
- [x] AI 컨테이너 + Alloy 컨테이너 동시 기동 확인
- [x] Grafana에서 AI EC2 메트릭/로그 수신 확인